### PR TITLE
[cthacker-udel-patch-1] Removed div

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,15 +14,11 @@ import LoginPage from "./modules/LoginPage";
  * @returns {JSX.Element} App component
  */
 const App = (): JSX.Element => (
-    <Container
-        className="vh-100 p-0 d-flex flex-column justify-content-between"
-        fluid
-    >
-        <BrowserRouter window={window}>
-            <IntlProvider
-                defaultLocale="en"
-                locale="en"
-                messages={homeMessages}
+    <BrowserRouter window={window}>
+        <IntlProvider defaultLocale="en" locale="en" messages={homeMessages}>
+            <Container
+                className="vh-100 p-0 d-flex flex-column justify-content-between"
+                fluid
             >
                 <Routes>
                     <Route element={<Layout />} path="/">
@@ -48,9 +44,9 @@ const App = (): JSX.Element => (
                     </Route> */}
                     </Route>
                 </Routes>
-            </IntlProvider>
-        </BrowserRouter>
-    </Container>
+            </Container>
+        </IntlProvider>
+    </BrowserRouter>
 );
 
 // eslint-disable-next-line jest/require-hook -- Not a jest test

--- a/client/src/modules/common/components/Layout/Layout.tsx
+++ b/client/src/modules/common/components/Layout/Layout.tsx
@@ -255,7 +255,7 @@ export const Layout = (): JSX.Element => {
     ];
 
     return (
-        <div>
+        <>
             <div>
                 <Outlet />
             </div>
@@ -269,6 +269,6 @@ export const Layout = (): JSX.Element => {
                 </Navbar>
             </div>
             {overlays}
-        </div>
+        </>
     );
 };


### PR DESCRIPTION
#### DESCRIPTION

The div component was actually causing major UI bug where we have a bootstrap style `space between` which places space `between` every element, but because everything was nested in **1** div, it didn't apply the spacing at all, once the div was removed, the app was the proper look.

I certify that I have

- [x] Assigned myself to the PR
- [x] Requested a reviewer for the PR
- [x] Reviewed the changes
- [x] Consulted my team that changes are pending
- [x] Verified that changes work
- [ x] Removed all prints and comments
- [x] Resolved all linting errors
- [x] Current implementation successfully runs
